### PR TITLE
redirect old law dev site to the new one

### DIFF
--- a/rules/rules.json
+++ b/rules/rules.json
@@ -1,4 +1,5 @@
 [
+    "^/(.*) https://law.tamu.edu.dev.sites-marcom.cloud.tamu.edu/ [H=^dev.law.cloud.tamu.edu$,R=301,L]",
     "^//.* /index.html [R,L]",
     "^(.*)/$ $1/index.html [R,L]",
     "^(((?!\\.).)*)?(/\\?.*)$ $1/index.html [R,L]",


### PR DESCRIPTION
There has been confusion based on old bookmarks and some users are finding this site and wondering why everything still looks broken.